### PR TITLE
initial release of `editorconfig`

### DIFF
--- a/.changeset/hip-sheep-brush.md
+++ b/.changeset/hip-sheep-brush.md
@@ -1,0 +1,5 @@
+---
+'@guardian/editorconfig': patch
+---
+
+Initial release


### PR DESCRIPTION
## What does this change?

adds a first changeset to describe the initial release of `@guardian/editorconfig`